### PR TITLE
ESIF_US: lin: main.c: Add sys/file.h header

### DIFF
--- a/ESIF/Products/ESIF_UF/Sources/lin/main.c
+++ b/ESIF/Products/ESIF_UF/Sources/lin/main.c
@@ -21,6 +21,7 @@
 #include <termios.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/file.h>
 
 #include "esif_uf.h"
 #include "esif_uf_appmgr.h"


### PR DESCRIPTION
Avoid implicit declaration of function 'flock' as this is invalid in C99 and the compiler will issue a warning.

Signed-off-by: Valentin Ilie <valentin.ilie@intel.com>